### PR TITLE
escape $ in manifest.yaml templates.

### DIFF
--- a/proton-cdk
+++ b/proton-cdk
@@ -455,7 +455,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat cdk-outputs.json | ./cdk-to-proton.sh > proton-outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./proton-outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn \$RESOURCE_ARN --outputs file://./proton-outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install
@@ -481,7 +481,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat cdk-outputs.json | ./cdk-to-proton.sh > proton-outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./proton-outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn \$RESOURCE_ARN --outputs file://./proton-outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install

--- a/src/lib/proton_templates.sh
+++ b/src/lib/proton_templates.sh
@@ -89,7 +89,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat cdk-outputs.json | ./cdk-to-proton.sh > proton-outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./proton-outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn \$RESOURCE_ARN --outputs file://./proton-outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install
@@ -115,7 +115,7 @@ infrastructure:
           - chmod +x ./cdk-to-proton.sh
           - cat cdk-outputs.json | ./cdk-to-proton.sh > proton-outputs.json
           # Notify AWS Proton of deployment status
-          - aws proton notify-resource-deployment-status-change --resource-arn $RESOURCE_ARN --outputs file://./proton-outputs.json
+          - aws proton notify-resource-deployment-status-change --resource-arn \$RESOURCE_ARN --outputs file://./proton-outputs.json
         deprovision:
           # Install dependencies and destroy resources
           - npm install


### PR DESCRIPTION
lib/proton_templates.sh make templates with HERE DOCUMENT feature.
it contains $RESOURCE_ARN, but it will disappear at rendering manifest.yaml

it should escape with \(backslash) about $.